### PR TITLE
Prefill form with existing bookmark information

### DIFF
--- a/src/form.svelte
+++ b/src/form.svelte
@@ -2,7 +2,7 @@
 
   import TagAutocomplete from './TagAutocomplete.svelte'
   import { getCurrentTabInfo, openOptions } from "./browser";
-  import { getTags, saveBookmark } from "./linkding";
+  import { getTags, saveBookmark, search } from "./linkding";
 
   let url = "";
   let title = "";
@@ -19,6 +19,14 @@
     titlePlaceholder = tabInfo.title;
     const availableTags = await getTags().catch(() => [])
     availableTagNames = availableTags.map(tag => tag.name)
+
+    const bookmarksFound = await search(url, { limit: 1000 }).catch(() => [])
+    const matchingBookmark = bookmarksFound.filter(bookmark => bookmark.url === url)[0]
+    if (matchingBookmark) {
+      tags = matchingBookmark.tag_names.join(" ")
+      title = matchingBookmark.website_title
+      description = matchingBookmark.website_description
+    }
   }
 
   init();


### PR DESCRIPTION
Using the extension, I often find myself wondering if a bookmark already exists or not in order to not mistakenly override any of the metadata already saved.

To find out if that's the case, I either have to search using the omnibox or linkding itself. Neither are perfect for that purpose as they don't indicate if the URL is an exact match and they each require multiple steps.

This PR is about prefilling the form with the information already existing in linkding if there is any exact URL match.