### PR TITLE
Add Logic to show existing bookmark information if already saved.

### DIFF
--- a/src/form.svelte
+++ b/src/form.svelte
@@ -2,7 +2,7 @@
 
   import TagAutocomplete from './TagAutocomplete.svelte'
   import { getCurrentTabInfo, openOptions } from "./browser";
-  import { getTags, saveBookmark } from "./linkding";
+  import { getTags, saveBookmark, lookForCurrentBookmark } from "./linkding";
 
   let url = "";
   let title = "";
@@ -12,6 +12,7 @@
   let saveState = "";
   let errorMessage = "";
   let availableTagNames = []
+  let formTitle = "";
 
   async function init() {
     const tabInfo = await getCurrentTabInfo();
@@ -19,6 +20,30 @@
     titlePlaceholder = tabInfo.title;
     const availableTags = await getTags().catch(() => [])
     availableTagNames = availableTags.map(tag => tag.name)
+
+   initCurrentBookmarkData();
+  }
+
+  async function initCurrentBookmarkData() {
+    formTitle = 'Searching for existing Bookmarks';
+
+     var bookmarkSearch = await lookForCurrentBookmark(url)
+        .catch(() => []);
+
+    if ( bookmarkSearch && bookmarkSearch.length > 0 ) {
+        var temp = bookmarkSearch[0];
+        formTitle = 'Edit Bookmark';
+        title = temp.title;
+        tags = (temp.tag_names ? temp.tag_names.join(' ') : "");
+        description = temp.description;
+      } else {
+        formTitle = 'Add Bookmark';
+        title = "";
+        tags = "";
+        description = "";
+      }
+    console.log("BookmarkSearch = " + bookmarkSearch);
+    
   }
 
   init();
@@ -49,7 +74,7 @@
 
 </script>
 <div class="title-row">
-  <h6>Add bookmark</h6>
+  <h6 id="bookmark-title">{formTitle} </h6>
   <a href="#" on:click|preventDefault={handleOptions}>Options</a>
 </div>
 <div class="divider"></div>
@@ -77,7 +102,7 @@
   <div class="divider"></div>
   {#if saveState === 'success'}
     <div class="form-group has-success result-row">
-      <div class="form-input-hint"><i class="icon icon-check"></i> Bookmark added</div>
+      <div class="form-input-hint"><i class="icon icon-check"></i> Bookmark saved</div>
     </div>
   {/if}
   {#if saveState === 'error'}

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -12,7 +12,8 @@
   let saveState = "";
   let errorMessage = "";
   let availableTagNames = []
-  let formTitle = "";
+  let formTitle = "Add Bookmark";
+  let bookmarkExistsWarning = "";
 
   async function init() {
     const tabInfo = await getCurrentTabInfo();
@@ -21,27 +22,27 @@
     const availableTags = await getTags().catch(() => [])
     availableTagNames = availableTags.map(tag => tag.name)
 
-   initCurrentBookmarkData();
+    loadExistingBookmarkData();
   }
 
-  async function initCurrentBookmarkData() {
-    formTitle = 'Searching for existing Bookmarks';
+  async function loadExistingBookmarkData() {
 
-     var bookmarkSearch = await lookForCurrentBookmark(url)
+     const foundBookmark = await lookForCurrentBookmark(url)
         .catch(() => []);
 
-    if ( bookmarkSearch && bookmarkSearch.length > 0 ) {
-        var temp = bookmarkSearch[0];
+    if (foundBookmark) {
         formTitle = 'Edit Bookmark';
-        title = temp.title;
-        tags = (temp.tag_names ? temp.tag_names.join(' ') : "");
-        description = temp.description;
+        title = foundBookmark.title;
+        tags = foundBookmark.tag_names ? foundBookmark.tag_names.join(" ") : "";
+        description = foundBookmark.description;
+        bookmarkExistsWarning = "This URL is already bookmarked. Making changes here will overwrite the existing bookmark when saving this form.";
       } else {
         formTitle = 'Add Bookmark';
         title = "";
         tags = "";
         description = "";
-      }    
+        bookmarkExistsWarning = "";
+      }
   }
 
   init();
@@ -72,7 +73,7 @@
 
 </script>
 <div class="title-row">
-  <h6 id="bookmark-title">{formTitle} </h6>
+  <h6>{formTitle}</h6>
   <a href="#" on:click|preventDefault={handleOptions}>Options</a>
 </div>
 <div class="divider"></div>
@@ -81,6 +82,9 @@
     <label class="form-label label-sm" for="input-url">URL</label>
     <input class="form-input input-sm" type="text" id="input-url" placeholder="URL"
            bind:value={url}>
+    <div class="form-input-hint bookmark-exists" style="display: block;">
+       {bookmarkExistsWarning}
+    </div>
   </div>
   <div class="form-group">
     <label class="form-label label-sm" for="input-tags">Tags</label>
@@ -134,5 +138,11 @@
     .result-row {
         display: flex;
         justify-content: center;
+    }
+
+    .bookmark-exists {
+      color: red;
+      margin-top: .2rem;
+      font-size: x-small;
     }
 </style>

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -41,9 +41,7 @@
         title = "";
         tags = "";
         description = "";
-      }
-    console.log("BookmarkSearch = " + bookmarkSearch);
-    
+      }    
   }
 
   init();

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -1,4 +1,4 @@
-import { getConfiguration } from "./configuration";
+import {getConfiguration} from "./configuration";
 
 export async function saveBookmark(bookmark) {
   const configuration = getConfiguration();
@@ -67,10 +67,7 @@ export async function testConnection(configuration) {
     .catch(() => false);
 }
 
-export async function lookForCurrentBookmark(url) {
-  return search(url, { "limit": 1 })
-      .then(body => body && body.length > 0 ? body[0] : undefined)
-      .catch(error => {
-        console.error(error);
-      });
+export async function findBookmarkByUrl(url) {
+  return search(url, {"limit": 1})
+    .then(results => results && results.length > 0 ? results[0] : undefined);
 }

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -68,18 +68,9 @@ export async function testConnection(configuration) {
 }
 
 export async function lookForCurrentBookmark(url) {
-  const configuration = getConfiguration();
-
-  var encodedUrl = encodeURIComponent(url);
-  return fetch(`${configuration.baseUrl}/api/bookmarks/?q=${encodedUrl}&limit=1`, {
-    headers: {
-      "Authorization": `Token ${configuration.token}`
-    }
-  })
-    .then(response => {
-      if (response.status === 200) {
-        return response.json().then(body => body.results);
-      }
-      return Promise.reject(`Error searching for existing bookmarks: ${response.statusText}`);
-    });
+  return search(url, { "limit": 1 })
+      .then(body => body && body.length > 0 ? body[0] : undefined)
+      .catch(error => {
+        console.error(error);
+      });
 }

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -66,3 +66,20 @@ export async function testConnection(configuration) {
     .then(body => !!body.results)
     .catch(() => false);
 }
+
+export async function lookForCurrentBookmark(url) {
+  const configuration = getConfiguration();
+
+  var encodedUrl = encodeURIComponent(url);
+  return fetch(`${configuration.baseUrl}/api/bookmarks/?q=${encodedUrl}&limit=1`, {
+    headers: {
+      "Authorization": `Token ${configuration.token}`
+    }
+  })
+    .then(response => {
+      if (response.status === 200) {
+        return response.json().then(body => body.results);
+      }
+      return Promise.reject(`Error searching for existing bookmarks: ${response.statusText}`);
+    });
+}


### PR DESCRIPTION
As requested in "Show whether page already bookmarked #14" on the issues, add logic to show if the current page is already bookmarked and if it is, pre-populate the form data.

What is changing:
1. Change popup title to either "Add Bookmark" or "Edit Bookmark" based on if url is already bookmarked
2. If bookmark is already saved, pre-populate the input boxes based on data from original bookmark.

After reading an older PR, it was discussed about performance as that implementation was pulling back all bookmarks and then filtering in javascript.  This implementation uses the query API with a limit of 1.   We also use the title of the popup dialog to denote if we are adding or editing an existing bookmark.  I think this is the easiest and most accessible way to denote if a page is already bookmarked.  