### PR TITLE
Fetch website title/description when adding new bookmark

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
   },
 
   "permissions": [
-    "tabs"
+    "tabs",
+    "scripting"
   ],
 
   "host_permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "linkding extension",
   "version": "1.3",
   "description": "Companion extension for the linkding bookmark service",
@@ -12,14 +12,14 @@
   },
 
   "background": {
-    "scripts": ["build/background.js"]
+    "service_worker": "build/background.js"
   },
 
   "omnibox": {
     "keyword": "ld"
   },
 
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "icons/button_19x19.png",
       "32": "icons/button_32x32.png",
@@ -43,7 +43,10 @@
   },
 
   "permissions": [
-    "tabs",
+    "tabs"
+  ],
+
+  "host_permissions": [
     "http://*/*",
     "https://*/*"
   ]

--- a/src/browser.js
+++ b/src/browser.js
@@ -2,6 +2,11 @@ function isChrome() {
   return typeof chrome !== "undefined";
 }
 
+function getMeta() {
+  var meta = document.querySelector('meta[name="description" i], meta[property="og:description" i]');
+  return { description: meta ? meta.content : "" }
+}
+
 export function getBrowser() {
   return isChrome() ? chrome : browser;
 }
@@ -15,9 +20,18 @@ export async function getCurrentTabInfo() {
   const tabs = await tabsPromise;
   const tab = tabs && tabs[0];
 
+  const tabsMetaPromise = isChrome() ? new Promise(resolve => getBrowser().scripting.executeScript({
+    target: {tabId: tab.id},
+    func: getMeta
+  }, resolve)) : getBrowser().scripting.executeScript({ target: {tabId: tab.id}, func: getMeta });
+
+  const metas = await tabsMetaPromise;
+  const meta = metas && metas[0] && metas[0].result;
+
   return {
     url: tab ? tab.url : "",
-    title: tab ? tab.title : ""
+    title: tab ? tab.title : "",
+    description: meta ? meta.description : ""
   };
 }
 

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -8,6 +8,7 @@
   let title = "";
   let titlePlaceholder = "";
   let description = "";
+  let descriptionPlaceholder = "";
   let tags = "";
   let saveState = "";
   let errorMessage = "";
@@ -18,6 +19,7 @@
     const tabInfo = await getCurrentTabInfo();
     url = tabInfo.url;
     titlePlaceholder = tabInfo.title;
+    descriptionPlaceholder = tabInfo.description;
     const availableTags = await getTags().catch(() => [])
     availableTagNames = availableTags.map(tag => tag.name)
 
@@ -42,8 +44,8 @@
     const tagNames = tags.split(" ").map(tag => tag.trim()).filter(tag => !!tag);
     const bookmark = {
       url,
-      title,
-      description,
+      title: title ? title : titlePlaceholder,
+      description: description ? description : descriptionPlaceholder,
       tag_names: tagNames
     };
 
@@ -93,7 +95,7 @@
     <label class="form-label label-sm" for="input-description">Description</label>
     <textarea class="form-input input-sm" id="input-description"
               bind:value={description}
-              placeholder="Leave empty to use description from website"></textarea>
+              placeholder={descriptionPlaceholder}></textarea>
   </div>
   <div class="divider"></div>
   {#if saveState === 'success'}


### PR DESCRIPTION
This pr will update the manifest to use V3 instead of V2 (the end is near: https://developer.chrome.com/blog/mv2-transition/ ).

Using the new scripting API ( https://developer.chrome.com/blog/crx-scripting-api/ ) it will autofill the description field in the popup from the meta tag on website. Currently the backend has some problems with strict Cloudflare rules and can't always fetch the website description, so the extension will fetch it itself.

It's a solution to solve: https://github.com/sissbruecker/linkding/issues/118

I did not test it in Firefox and `npx web-ext lint` breaks with manifest V3, that's the reason why marked it as draft.