### PR TITLE
Add theme options

### DIFF
--- a/src/TagAutocomplete.svelte
+++ b/src/TagAutocomplete.svelte
@@ -1,135 +1,148 @@
 <script>
-    import {getCurrentWord, getCurrentWordBounds} from "./util";
+  import { getCurrentWord, getCurrentWordBounds } from './util';
 
-    export let id;
-    export let name;
-    export let value;
-    export let tags;
+  export let id;
+  export let name;
+  export let value;
+  export let tags;
 
-    let isFocus = false;
-    let isOpen = false;
-    let input = null;
+  let isFocus = false;
+  let isOpen = false;
+  let input = null;
 
-    let suggestions = [];
-    let selectedIndex = 0;
+  let suggestions = [];
+  let selectedIndex = 0;
 
-    function handleFocus() {
-        isFocus = true;
+  function handleFocus() {
+    isFocus = true;
+  }
+
+  function handleBlur() {
+    isFocus = false;
+    close();
+  }
+
+  function handleInput(e) {
+    input = e.target;
+
+    const word = getCurrentWord(input);
+
+    suggestions = word ? tags.filter((tag) => tag.indexOf(word) === 0) : [];
+
+    if (word && suggestions.length > 0) {
+      open();
+    } else {
+      close();
     }
+  }
 
-    function handleBlur() {
-        isFocus = false;
-        close();
+  function handleKeyDown(e) {
+    if (isOpen && (e.keyCode === 13 || e.keyCode === 9)) {
+      const suggestion = suggestions[selectedIndex];
+      complete(suggestion);
+      e.preventDefault();
     }
-
-    function handleInput(e) {
-        input = e.target;
-
-        const word = getCurrentWord(input);
-
-        suggestions = word ? tags.filter(tag => tag.indexOf(word) === 0) : [];
-
-        if (word && suggestions.length > 0) {
-            open();
-        } else {
-            close();
-        }
+    if (e.keyCode === 27) {
+      close();
+      e.preventDefault();
     }
-
-    function handleKeyDown(e) {
-        if (isOpen && (e.keyCode === 13 || e.keyCode === 9)) {
-            const suggestion = suggestions[selectedIndex];
-            complete(suggestion);
-            e.preventDefault();
-        }
-        if (e.keyCode === 27) {
-            close();
-            e.preventDefault();
-        }
-        if (e.keyCode === 38) {
-            updateSelection(-1);
-            e.preventDefault();
-        }
-        if (e.keyCode === 40) {
-            updateSelection(1);
-            e.preventDefault();
-        }
+    if (e.keyCode === 38) {
+      updateSelection(-1);
+      e.preventDefault();
     }
-
-    function open() {
-        isOpen = true;
-        selectedIndex = 0;
+    if (e.keyCode === 40) {
+      updateSelection(1);
+      e.preventDefault();
     }
+  }
 
-    function close() {
-        isOpen = false;
-        suggestions = [];
-        selectedIndex = 0;
-    }
+  function open() {
+    isOpen = true;
+    selectedIndex = 0;
+  }
 
-    function complete(suggestion) {
-        const bounds = getCurrentWordBounds(input);
-        const inputValue = input.value;
-        value = inputValue.substring(0, bounds.start) + suggestion + inputValue.substring(bounds.end);
+  function close() {
+    isOpen = false;
+    suggestions = [];
+    selectedIndex = 0;
+  }
 
-        close();
-    }
+  function complete(suggestion) {
+    const bounds = getCurrentWordBounds(input);
+    const inputValue = input.value;
+    value =
+      inputValue.substring(0, bounds.start) +
+      suggestion +
+      inputValue.substring(bounds.end);
 
-    function updateSelection(dir) {
+    close();
+  }
 
-        const length = suggestions.length;
-        let newIndex = selectedIndex + dir;
+  function updateSelection(dir) {
+    const length = suggestions.length;
+    let newIndex = selectedIndex + dir;
 
-        if (newIndex < 0) newIndex = Math.max(length - 1, 0);
-        if (newIndex >= length) newIndex = 0;
+    if (newIndex < 0) newIndex = Math.max(length - 1, 0);
+    if (newIndex >= length) newIndex = 0;
 
-        selectedIndex = newIndex;
-    }
+    selectedIndex = newIndex;
+  }
 </script>
 
 <div class="form-autocomplete">
-    <!-- autocomplete input container -->
-    <div class="form-autocomplete-input form-input" class:is-focused={isFocus}>
-        <!-- autocomplete real input box -->
-        <input id="{id}" name="{name}" autofocus
-               class="form-input input-sm" type="text" autocomplete="off"
-               bind:value={value}
-               on:input={handleInput} on:keydown={handleKeyDown}
-               on:focus={handleFocus} on:blur={handleBlur}>
-    </div>
+  <!-- autocomplete input container -->
+  <div class="form-autocomplete-input form-input" class:is-focused={isFocus}>
+    <!-- autocomplete real input box -->
+    <input
+      {id}
+      {name}
+      autofocus
+      class="form-input input-sm"
+      type="text"
+      autocomplete="off"
+      bind:value
+      on:input={handleInput}
+      on:keydown={handleKeyDown}
+      on:focus={handleFocus}
+      on:blur={handleBlur}
+    />
+  </div>
 
-    <!-- autocomplete suggestion list -->
-    <ul class="menu" class:open={isOpen && suggestions.length > 0}>
-        <!-- menu list items -->
-        {#each suggestions as tag,i}
-            <li class="menu-item" class:selected={selectedIndex === i}>
-                <a href="#" on:mousedown|preventDefault={() => complete(tag)}>
-                    <div class="tile tile-centered">
-                        <div class="tile-content">
-                            {tag}
-                        </div>
-                    </div>
-                </a>
-            </li>
-        {/each}
-    </ul>
+  <!-- autocomplete suggestion list -->
+  <ul class="menu" class:open={isOpen && suggestions.length > 0}>
+    <!-- menu list items -->
+    {#each suggestions as tag, i}
+      <li class="menu-item" class:selected={selectedIndex === i}>
+        <a href="#" on:mousedown|preventDefault={() => complete(tag)}>
+          <div class="tile tile-centered">
+            <div class="tile-content">
+              {tag}
+            </div>
+          </div>
+        </a>
+      </li>
+    {/each}
+  </ul>
 </div>
 
 <style>
-    .menu {
-        display: none;
-        max-height: 200px;
-        overflow: auto;
-        font-size: .7rem;
-    }
+  .menu {
+    display: none;
+    max-height: 200px;
+    overflow: auto;
+    font-size: 0.7rem;
 
-    .menu.open {
-        display: block;
-    }
+    background: var(--base-200);
+    color: var(--primary);
+  }
 
-    /* TODO: Should be read from theme */
-    .menu-item.selected > a {
-        background: #f1f1fc;
-        color: #5755d9;
-    }
+  .menu.open {
+    display: block;
+  }
+
+  /* TODO: Should be read from theme */
+  .menu-item.selected > a {
+    background: var(--base-300);
+    color: var(--primary);
+  }
 </style>

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,18 +1,20 @@
-const CONFIG_KEY = 'ld_ext_config'
+const CONFIG_KEY = 'ld_ext_config';
 
 export function getConfiguration() {
-  const configJson = localStorage.getItem(CONFIG_KEY)
-  const config = configJson ? JSON.parse(configJson) : {baseUrl: '', token: ''}
-  return config
+  const configJson = localStorage.getItem(CONFIG_KEY);
+  const config = configJson
+    ? JSON.parse(configJson)
+    : { baseUrl: '', token: '', theme: 'auto' };
+  return config;
 }
 
 export function saveConfiguration(config) {
-  const configJson = JSON.stringify(config)
-  localStorage.setItem(CONFIG_KEY, configJson)
+  const configJson = JSON.stringify(config);
+  localStorage.setItem(CONFIG_KEY, configJson);
 }
 
 export function isConfigurationComplete() {
-  const config = getConfiguration()
+  const config = getConfiguration();
 
-  return config.baseUrl && config.token
+  return config.baseUrl && config.token && config.theme;
 }

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -1,9 +1,10 @@
 <script>
-  import { getConfiguration, saveConfiguration } from "./configuration";
-  import { testConnection } from "./linkding";
+  import { getConfiguration, saveConfiguration } from './configuration';
+  import { testConnection } from './linkding';
 
-  let baseUrl = "";
-  let token = "";
+  let baseUrl = '';
+  let token = '';
+  let theme = 'auto';
   let isSuccess = false;
   let isError = false;
 
@@ -11,6 +12,9 @@
     const config = getConfiguration();
     baseUrl = config.baseUrl;
     token = config.token;
+    theme = config.theme;
+
+    document.body.dataset['theme'] = theme;
   }
 
   init();
@@ -18,13 +22,17 @@
   async function handleSubmit() {
     const config = {
       baseUrl,
-      token
+      token,
+      theme,
     };
 
     const testResult = await testConnection(config);
 
     if (testResult) {
       saveConfiguration(config);
+
+      document.body.dataset['theme'] = theme;
+
       isError = false;
       isSuccess = true;
     } else {
@@ -33,50 +41,95 @@
     }
   }
 </script>
+
 <h6>Configuration</h6>
-<div class="divider"></div>
-<p>This is a companion extension for the <a href="https://github.com/sissbruecker/linkding">linkding</a> bookmark
-  service. Before you can start using it you have to configure some basic settings, so that the extension can
-  communicate with your linkding installation.</p>
+<div class="divider" />
+<p>
+  This is a companion extension for the <a
+    href="https://github.com/sissbruecker/linkding">linkding</a
+  > bookmark service. Before you can start using it you have to configure some basic
+  settings, so that the extension can communicate with your linkding installation.
+</p>
 <form class="form" on:submit|preventDefault={handleSubmit}>
   <div class="form-group">
     <label class="form-label" for="input-base-url">Base URL</label>
-    <input class="form-input" type="text" id="input-base-url" placeholder="https://linkding.mydomain.com"
-           bind:value={baseUrl}>
-    <div class="form-input-hint">The base URL of your linkding installation, <b>without</b> the <samp>/bookmark</samp> path or a trailing slash</div>
+    <input
+      class="form-input"
+      type="text"
+      id="input-base-url"
+      placeholder="https://linkding.mydomain.com"
+      bind:value={baseUrl}
+    />
+    <div class="form-input-hint">
+      The base URL of your linkding installation, <b>without</b> the
+      <samp>/bookmark</samp> path or a trailing slash
+    </div>
   </div>
   <div class="form-group">
     <label class="form-label" for="input-token">API Authentication Token</label>
-    <input class="form-input" type="password" id="input-token" placeholder="Token" bind:value={token}>
-    <div class="form-input-hint">Used to authenticate against the linkding API. You can find this on your linkding
-      settings page.
+    <input
+      class="form-input"
+      type="password"
+      id="input-token"
+      placeholder="Token"
+      bind:value={token}
+    />
+    <div class="form-input-hint">
+      Used to authenticate against the linkding API. You can find this on your
+      linkding settings page.
     </div>
   </div>
-  <div class="divider"></div>
+  <div class="form-group">
+    <label class="form-label" for="input-theme">Theme</label>
+    <select
+      name="input-theme"
+      class="form-select col-2 col-sm-12"
+      id="input-theme"
+      bind:value={theme}
+    >
+      <option value="auto">Auto</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+    <div class="form-input-hint">
+      Whether to use a light or dark theme, or automatically adjust the theme
+      based on your system's settings.
+    </div>
+  </div>
+  <div class="divider" />
   <div class="button-row">
     {#if isSuccess}
       <div class="form-group has-success mr-2">
-        <span class="form-input-hint"><i class="icon icon-check"></i> Connection successful</span>
+        <span class="form-input-hint"
+          ><i class="icon icon-check" /> Connection successful</span
+        >
       </div>
     {/if}
     {#if isError}
       <div class="form-group has-error mr-2">
-        <span class="form-input-hint"><i class="icon icon-cross"></i> Connection failed</span>
+        <span class="form-input-hint"
+          ><i class="icon icon-cross" /> Connection failed</span
+        >
       </div>
     {/if}
-    <button type="submit" class="btn btn-primary ml-2" disabled={!(baseUrl && token)}>
+    <button
+      type="submit"
+      class="btn btn-primary ml-2"
+      disabled={!(baseUrl && token)}
+    >
       Save
     </button>
   </div>
 </form>
+
 <style>
-    .button-row {
-        display: flex;
-        justify-content: flex-end;
-        align-items: baseline;
-    }
-    .button-row button {
-        padding-left: 32px;
-        padding-right: 32px;
-    }
+  .button-row {
+    display: flex;
+    justify-content: flex-end;
+    align-items: baseline;
+  }
+  .button-row button {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
 </style>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,82 @@
+:root {
+  --base-100: #ffffff;
+  --base-200: #f1f1fc;
+  --base-300: #f1f1fc;
+  --primary: #5755d9;
+  --color: #66758c;
+  --hint: #bcc3ce;
+  --border: #dadee4;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --base-100: #161822;
+    --base-200: #202331;
+    --base-300: #2a2e41;
+    --primary: #5755d9;
+    --color: #b8bdc8;
+    --hint: #7f879b;
+    --border: #4c4e53;
+  }
+}
+
+[data-theme='light'] {
+  --base-100: #ffffff;
+  --base-200: #f1f1fc;
+  --base-300: #f1f1fc;
+  --primary: #5755d9;
+  --color: #66758c;
+  --hint: #bcc3ce;
+  --border: #dadee4;
+}
+
+[data-theme='dark'] {
+  --base-100: #161822;
+  --base-200: #202331;
+  --base-300: #2a2e41;
+  --primary: #5755d9;
+  --color: #b8bdc8;
+  --hint: #7f879b;
+  --border: #4c4e53;
+}
+
+:root,
+[data-theme],
 body {
-    padding: 16px;
-    min-width: 400px;
+  background-color: var(--base-100);
+  color: var(--color);
+}
+
+body {
+  padding: 16px;
+  min-width: 400px;
+}
+
+.form-select,
+.form-input {
+  color: inherit;
+  border-color: var(--border);
+}
+
+.form-select:focus,
+.form-input:focus {
+  border-color: var(--primary);
+}
+
+.form-input {
+  background: var(--base-200);
+}
+
+:is(.form-select, #increase#specificity) {
+  background-color: var(
+    --base-200
+  ) !important /* needed to override spectre.css entry*/;
+}
+
+.form-input-hint {
+  color: var(--hint);
+}
+
+.divider {
+  border-color: var(--border);
 }


### PR DESCRIPTION
This pull request adds theming (dark, light and auto) to the linkding extension, following the design of linkding itself. The selected theme can be set within `options.svelte` and is stored alongside the other configuration options in `configuration.js`.

Styling is mostly done within `index.css`, however some styles were changed within `TagAutocomplete.svelte` as well.