### PR TITLE
Refactor to support Chrome manifest V3

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,38 +1,56 @@
 import { getBrowser } from "./browser";
-import { search } from "./linkding";
+import { LinkdingApi } from "./linkding";
 import { getConfiguration, isConfigurationComplete } from "./configuration";
 
 const browser = getBrowser();
+let api = null;
+let configuration = null;
+let hasCompleteConfiguration = false;
 
-browser.omnibox.onInputStarted.addListener(() => {
-  const hasCompleteConfiguration = isConfigurationComplete();
+browser.omnibox.onInputStarted.addListener(async () => {
+  configuration = await getConfiguration();
+  hasCompleteConfiguration = isConfigurationComplete(configuration);
   const description = hasCompleteConfiguration
     ? "Search bookmarks in linkding"
     : "⚠️ Please configure the linkding extension first";
 
   browser.omnibox.setDefaultSuggestion({ description });
+
+  if (hasCompleteConfiguration) {
+    api = new LinkdingApi(configuration);
+  } else {
+    api = null;
+  }
 });
 
 browser.omnibox.onInputChanged.addListener((text, suggest) => {
-  search(text, { limit: 5 })
-    .then(results => {
-      const bookmarkSuggestions = results.map(bookmark => ({
+  if (!api) {
+    return;
+  }
+
+  api
+    .search(text, { limit: 5 })
+    .then((results) => {
+      const bookmarkSuggestions = results.map((bookmark) => ({
         content: bookmark.url,
-        description: bookmark.title || bookmark.website_title || bookmark.url
+        description: bookmark.title || bookmark.website_title || bookmark.url,
       }));
       suggest(bookmarkSuggestions);
     })
-    .catch(error => {
+    .catch((error) => {
       console.error(error);
     });
 });
 
 browser.omnibox.onInputEntered.addListener((content, disposition) => {
-  if (!content) return;
+  if (!hasCompleteConfiguration || !content) {
+    return;
+  }
 
-  const configuration = getConfiguration();
   const isUrl = /^http(s)?:\/\//.test(content);
-  const url = isUrl ? content : `${configuration.baseUrl}/bookmarks?q=${encodeURIComponent(content)}`;
+  const url = isUrl
+    ? content
+    : `${configuration.baseUrl}/bookmarks?q=${encodeURIComponent(content)}`;
 
   switch (disposition) {
     case "currentTab":

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,24 +1,37 @@
-function isChrome() {
-  return typeof chrome !== "undefined";
-}
-
 export function getBrowser() {
-  return isChrome() ? chrome : browser;
+  return typeof browser !== 'undefined' ? browser : chrome;
 }
 
 export async function getCurrentTabInfo() {
-  const tabsPromise = isChrome() ? new Promise(resolve => getBrowser().tabs.query({
-    active: true,
-    currentWindow: true
-  }, resolve)) : getBrowser().tabs.query({ active: true, currentWindow: true });
-
-  const tabs = await tabsPromise;
+  const tabs = await getBrowser().tabs.query({active: true, currentWindow: true});
   const tab = tabs && tabs[0];
 
   return {
     url: tab ? tab.url : "",
     title: tab ? tab.title : ""
   };
+}
+
+function useChromeStorage() {
+  return typeof chrome !== "undefined" && !!chrome.storage;
+}
+
+export function getStorageItem(key) {
+  if (useChromeStorage()) {
+    const result = chrome.storage.local.get([key]);
+    return result.then(data => data[key])
+  } else {
+    return Promise.resolve(localStorage.getItem(key));
+  }
+}
+
+export function setStorageItem(key, value) {
+  if (useChromeStorage()) {
+    return chrome.storage.local.set({[key]: value});
+  } else {
+    localStorage.setItem(key, value);
+    return Promise.resolve();
+  }
 }
 
 export function openOptions() {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,3 +1,5 @@
+import {getStorageItem, setStorageItem} from './browser';
+
 const CONFIG_KEY = 'ld_ext_config'
 const DEFAULTS = {
   baseUrl: '',
@@ -5,8 +7,8 @@ const DEFAULTS = {
   default_tags: '',
 }
 
-export function getConfiguration() {
-  const configJson = localStorage.getItem(CONFIG_KEY)
+export async function getConfiguration() {
+  const configJson = await getStorageItem(CONFIG_KEY)
   const config = configJson ? JSON.parse(configJson) : {}
   return {
     ...DEFAULTS,
@@ -14,13 +16,11 @@ export function getConfiguration() {
   }
 }
 
-export function saveConfiguration(config) {
+export async function saveConfiguration(config) {
   const configJson = JSON.stringify(config)
-  localStorage.setItem(CONFIG_KEY, configJson)
+  await setStorageItem(CONFIG_KEY, configJson)
 }
 
-export function isConfigurationComplete() {
-  const config = getConfiguration()
-
+export function isConfigurationComplete(config) {
   return config.baseUrl && config.token
 }

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -1,73 +1,87 @@
-import {getConfiguration} from "./configuration";
+export class LinkdingApi {
+  constructor(configuration) {
+    this.configuration = configuration;
+  }
 
-export async function saveBookmark(bookmark) {
-  const configuration = getConfiguration();
+  async saveBookmark(bookmark) {
+    const configuration = this.configuration;
 
-  return fetch(`${configuration.baseUrl}/api/bookmarks/`, {
-    method: "POST",
-    headers: {
-      "Authorization": `Token ${configuration.token}`,
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify(bookmark)
-  }).then(response => {
-    if (response.status === 201) {
-      return response.json();
-    } else if (response.status === 400) {
-      return response.json().then(body => Promise.reject(`Validation error: ${JSON.stringify(body)}`));
-    } else {
-      return Promise.reject(`Request error: ${response.statusText}`);
-    }
-  });
-}
+    return fetch(`${configuration.baseUrl}/api/bookmarks/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${configuration.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(bookmark),
+    }).then((response) => {
+      if (response.status === 201) {
+        return response.json();
+      } else if (response.status === 400) {
+        return response
+          .json()
+          .then((body) =>
+            Promise.reject(`Validation error: ${JSON.stringify(body)}`)
+          );
+      } else {
+        return Promise.reject(`Request error: ${response.statusText}`);
+      }
+    });
+  }
 
-export async function getTags() {
-  const configuration = getConfiguration();
+  async getTags() {
+    const configuration = this.configuration;
 
-  return fetch(`${configuration.baseUrl}/api/tags/?limit=1000`, {
-    headers: {
-      "Authorization": `Token ${configuration.token}`
-    }
-  })
-    .then(response => {
+    return fetch(`${configuration.baseUrl}/api/tags/?limit=1000`, {
+      headers: {
+        Authorization: `Token ${configuration.token}`,
+      },
+    }).then((response) => {
       if (response.status === 200) {
-        return response.json().then(body => body.results);
+        return response.json().then((body) => body.results);
       }
       return Promise.reject(`Error loading tags: ${response.statusText}`);
     });
-}
+  }
 
-export async function search(text, options) {
-  const configuration = getConfiguration();
-  const q = encodeURIComponent(text);
-  const limit = options.limit || 100;
+  async search(text, options) {
+    const configuration = this.configuration;
+    const q = encodeURIComponent(text);
+    const limit = options.limit || 100;
 
-  return fetch(`${configuration.baseUrl}/api/bookmarks/?q=${q}&limit=${limit}`, {
-    headers: {
-      "Authorization": `Token ${configuration.token}`
-    }
-  })
-    .then(response => {
-      if (response.status === 200) {
-        return response.json().then(body => body.results);
+    return fetch(
+      `${configuration.baseUrl}/api/bookmarks/?q=${q}&limit=${limit}`,
+      {
+        headers: {
+          Authorization: `Token ${configuration.token}`,
+        },
       }
-      return Promise.reject(`Error searching bookmarks: ${response.statusText}`);
+    ).then((response) => {
+      if (response.status === 200) {
+        return response.json().then((body) => body.results);
+      }
+      return Promise.reject(
+        `Error searching bookmarks: ${response.statusText}`
+      );
     });
-}
+  }
 
+  async testConnection() {
+    const configuration = this.configuration;
+    return fetch(`${configuration.baseUrl}/api/bookmarks/?limit=1`, {
+      headers: {
+        Authorization: `Token ${configuration.token}`,
+      },
+    })
+      .then((response) =>
+        response.status === 200 ? response.json() : Promise.reject(response)
+      )
+      .then((body) => !!body.results)
+      .catch(() => false);
+  }
 
-export async function testConnection(configuration) {
-  return fetch(`${configuration.baseUrl}/api/bookmarks/?limit=1`, {
-    headers: {
-      "Authorization": `Token ${configuration.token}`
-    }
-  })
-    .then(response => response.status === 200 ? response.json() : Promise.reject(response))
-    .then(body => !!body.results)
-    .catch(() => false);
-}
-
-export async function findBookmarkByUrl(url) {
-  return search(url, {"limit": 1})
-    .then(results => results && results.length > 0 ? results[0] : undefined);
+  async findBookmarkByUrl(url) {
+    return this.search(url, { limit: 1 }).then((results) =>
+      results && results.length > 0 ? results[0] : undefined
+    );
+  }
 }

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -1,6 +1,6 @@
 <script>
   import {getConfiguration, saveConfiguration} from "./configuration";
-  import {testConnection} from "./linkding";
+  import {LinkdingApi} from "./linkding";
 
   let baseUrl = "";
   let token = "";
@@ -8,8 +8,8 @@
   let isSuccess = false;
   let isError = false;
 
-  function init() {
-    const config = getConfiguration();
+  async function init() {
+    const config = await getConfiguration();
     baseUrl = config.baseUrl;
     token = config.token;
     default_tags = config.default_tags;
@@ -24,10 +24,10 @@
       default_tags,
     };
 
-    const testResult = await testConnection(config);
+    const testResult = await new LinkdingApi(config).testConnection(config);
 
     if (testResult) {
-      saveConfiguration(config);
+      await saveConfiguration(config);
       isError = false;
       isSuccess = true;
     } else {

--- a/src/popup.svelte
+++ b/src/popup.svelte
@@ -1,13 +1,35 @@
 <script>
   import Form from "./form.svelte";
   import Intro from "./intro.svelte";
-  import { isConfigurationComplete } from "./configuration";
+  import {getConfiguration, isConfigurationComplete} from "./configuration";
+  import {LinkdingApi} from "./linkding";
 
-  const hasCompleteConfiguration = isConfigurationComplete();
+  let hasCompleteConfiguration = true;
+  let configuration;
+  let api;
+
+  async function init() {
+    configuration = await getConfiguration();
+    hasCompleteConfiguration = isConfigurationComplete(configuration);
+    if (hasCompleteConfiguration) {
+      api = new LinkdingApi(configuration);
+    }
+  }
+
+  init();
 </script>
 
-{#if hasCompleteConfiguration}
-  <Form />
-{:else}
-  <Intro />
+<Form configuration="{configuration}" api="{api}"/>
+
+{#if !hasCompleteConfiguration}
+  <div class="modal active" id="modal-id">
+    <div class="modal-overlay"></div>
+    <div class="modal-container">
+      <div class="modal-body">
+        <div class="content">
+          <Intro/>
+        </div>
+      </div>
+    </div>
+  </div>
 {/if}


### PR DESCRIPTION
Refactors the extension to add support for extension manifest V3 for Chrome, while keeping support for manifest V2 for Firefox. All changes revolve around adding support for the `chrome.storage` API, which replaces `localStorage` in Chrome for V3. As a consequence all storage operations (getting / saving configuration) need to be async.

Regarding the manifest file, the `master` branch will continue to contain the manifest V2 file. Manifest V3 specific changes are going into a separate `chrome` branch.