### PR TITLE
Use server-side scraping

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,51 @@
+import { getStorageItem, setStorageItem } from "./browser";
+import { getConfiguration, isConfigurationComplete } from "./configuration";
+import { LinkdingApi } from "./linkding";
+
+const TAB_METADATA_CACHE_KEY = "ld_tab_metadata_cache";
+
+export async function loadTabMetadata(url) {
+  const configuration = await getConfiguration();
+  const hasCompleteConfiguration = isConfigurationComplete(configuration);
+
+  // Skip if extension is not configured or URL is invalid
+  if (!hasCompleteConfiguration || !url || !url.match(/^http(s)?:\/\//)) {
+    return null;
+  }
+
+  // Check for cached metadata first
+  const cachedMetadata = await getCachedTabMetadata();
+  if (cachedMetadata && cachedMetadata.metadata.url === url) {
+    return cachedMetadata;
+  }
+
+  // Load metadata if not cached
+  const api = new LinkdingApi(configuration);
+  try {
+    const tabMetadata = await api.check(url);
+    // Linkding <v1.17 does not return full bookmark data from check API
+    // In that case fetch the bookmark with a separate request
+    if (tabMetadata.bookmark && !tabMetadata.bookmark.date_added) {
+      tabMetadata.bookmark = await api.getBookmark(tabMetadata.bookmark.id);
+    }
+    await cacheTabMetadata(tabMetadata);
+    return tabMetadata;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+export async function getCachedTabMetadata() {
+  const json = await getStorageItem(TAB_METADATA_CACHE_KEY);
+  return json ? JSON.parse(json) : null;
+}
+
+export async function cacheTabMetadata(tabMetadata) {
+  const json = JSON.stringify(tabMetadata);
+  await setStorageItem(TAB_METADATA_CACHE_KEY, json);
+}
+
+export async function clearCachedTabMetadata() {
+  await cacheTabMetadata(null);
+}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,7 +1,6 @@
 import { getStorageItem, setStorageItem } from "./browser";
 
 const CONFIG_KEY = "ld_ext_config";
-const TAB_METADATA_CACHE_KEY = "ld_tab_metadata_cache";
 const DEFAULTS = {
   baseUrl: "",
   token: "",
@@ -20,20 +19,6 @@ export async function getConfiguration() {
 export async function saveConfiguration(config) {
   const configJson = JSON.stringify(config);
   await setStorageItem(CONFIG_KEY, configJson);
-}
-
-export async function getCachedTabMetadata() {
-  const json = await getStorageItem(TAB_METADATA_CACHE_KEY);
-  return json ? JSON.parse(json) : null;
-}
-
-export async function cacheTabMetadata(tabMetadata) {
-  const json = JSON.stringify(tabMetadata);
-  await setStorageItem(TAB_METADATA_CACHE_KEY, json);
-}
-
-export async function clearCachedTabMetadata() {
-  await cacheTabMetadata(null);
 }
 
 export function isConfigurationComplete(config) {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,26 +1,41 @@
-import {getStorageItem, setStorageItem} from './browser';
+import { getStorageItem, setStorageItem } from "./browser";
 
-const CONFIG_KEY = 'ld_ext_config'
+const CONFIG_KEY = "ld_ext_config";
+const TAB_METADATA_CACHE_KEY = "ld_tab_metadata_cache";
 const DEFAULTS = {
-  baseUrl: '',
-  token: '',
-  default_tags: '',
-}
+  baseUrl: "",
+  token: "",
+  default_tags: "",
+};
 
 export async function getConfiguration() {
-  const configJson = await getStorageItem(CONFIG_KEY)
-  const config = configJson ? JSON.parse(configJson) : {}
+  const configJson = await getStorageItem(CONFIG_KEY);
+  const config = configJson ? JSON.parse(configJson) : {};
   return {
     ...DEFAULTS,
     ...config,
-  }
+  };
 }
 
 export async function saveConfiguration(config) {
-  const configJson = JSON.stringify(config)
-  await setStorageItem(CONFIG_KEY, configJson)
+  const configJson = JSON.stringify(config);
+  await setStorageItem(CONFIG_KEY, configJson);
+}
+
+export async function getCachedTabMetadata() {
+  const json = await getStorageItem(TAB_METADATA_CACHE_KEY);
+  return json ? JSON.parse(json) : null;
+}
+
+export async function cacheTabMetadata(tabMetadata) {
+  const json = JSON.stringify(tabMetadata);
+  await setStorageItem(TAB_METADATA_CACHE_KEY, json);
+}
+
+export async function clearCachedTabMetadata() {
+  await cacheTabMetadata(null);
 }
 
 export function isConfigurationComplete(config) {
-  return config.baseUrl && config.token
+  return config.baseUrl && config.token;
 }

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -1,7 +1,7 @@
 <script>
   import TagAutocomplete from './TagAutocomplete.svelte'
   import {getCurrentTabInfo, openOptions} from "./browser";
-  import {getCachedTabMetadata, clearCachedTabMetadata} from "./configuration";
+  import {loadTabMetadata, clearCachedTabMetadata} from "./cache";
 
   export let api;
   export let configuration;
@@ -35,28 +35,22 @@
   }
 
   async function loadExistingBookmarkData() {
-    let tabMetadata = await getCachedTabMetadata();
-    if (!tabMetadata || tabMetadata.metadata.url !== url) {
-      tabMetadata = await api.check(url).catch(() => null)
+    const tabMetadata = await loadTabMetadata(url);
+    if (!tabMetadata) {
+      return;
     }
 
-    let existingBookmark = tabMetadata.bookmark;
+    titlePlaceholder = tabMetadata.metadata.title;
+    descriptionPlaceholder = tabMetadata.metadata.description;
 
+    const existingBookmark = tabMetadata.bookmark;
     if (existingBookmark) {
-      // Linkding <v1.17 does not return full bookmark data from check API
-      // In that case fetch the bookmark with a separate request
-      if (!existingBookmark.date_added) {
-        existingBookmark = await api.getBookmark(existingBookmark.id);
-      }
       bookmarkExists = true;
       title = existingBookmark.title;
       tags = existingBookmark.tag_names ? existingBookmark.tag_names.join(" ") : "";
       description = existingBookmark.description;
       unread = existingBookmark.unread;
     }
-
-    titlePlaceholder = tabMetadata.metadata.title;
-    descriptionPlaceholder = tabMetadata.metadata.description;
   }
 
   async function handleSubmit() {

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -3,6 +3,26 @@ export class LinkdingApi {
     this.configuration = configuration;
   }
 
+  async getBookmark(bookmarkId) {
+    const configuration = this.configuration;
+
+    return fetch(
+      `${configuration.baseUrl}/api/bookmarks/${bookmarkId}/`,
+      {
+        headers: {
+          Authorization: `Token ${configuration.token}`,
+        },
+      }
+    ).then((response) => {
+      if (response.status === 200) {
+        return response.json();
+      }
+      return Promise.reject(
+        `Error retrieving bookmark: ${response.statusText}`
+      );
+    });
+  }
+
   async saveBookmark(bookmark) {
     const configuration = this.configuration;
 
@@ -61,6 +81,27 @@ export class LinkdingApi {
       }
       return Promise.reject(
         `Error searching bookmarks: ${response.statusText}`
+      );
+    });
+  }
+
+  async check(url) {
+    const configuration = this.configuration;
+    url = encodeURIComponent(url);
+
+    return fetch(
+      `${configuration.baseUrl}/api/bookmarks/check/?url=${url}`,
+      {
+        headers: {
+          Authorization: `Token ${configuration.token}`,
+        },
+      }
+    ).then((response) => {
+      if (response.status === 200) {
+        return response.json();
+      }
+      return Promise.reject(
+        `Error checking bookmark URL: ${response.statusText}`
       );
     });
   }


### PR DESCRIPTION
Changes the extension to use server-side scraping, like the in-app bookmark form / bookmarklet. Previously the extension form would only show the tab title as preview value, which could be misleading as the saved bookmark will always use the website title scraped by the server. Tab title and scraped title can be different in some cases, for example when a website does not properly update its title on client-side navigation (e.g. Github sometimes), or when the website can not be scraped by the server (e.g. Cloudflare bot protection). Now the extension will always show the title and description that then will also be used by the server.

This change also includes a pre-caching mechanism, which attempts to load website metadata whenever the active tab or its URL changes. This allows to show the website metadata, and whether a URL is already bookmarked, immediately when opening the extension form. Together with [adding a caching mechanism for website metadata](https://github.com/sissbruecker/linkding/pull/401) to the linkding server, this should also make saving bookmarks pretty much instant in most cases.

Fixes https://github.com/sissbruecker/linkding-extension/issues/28