### PR TITLE
Add page metadata pre-load option

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -82,7 +82,7 @@ browser.omnibox.onInputEntered.addListener((content, disposition) => {
 
 browser.tabs.onActivated.addListener(async () => {
   const tabInfo = await getCurrentTabInfo();
-  await loadTabMetadata(tabInfo.url);
+  await loadTabMetadata(tabInfo.url, true);
 });
 
 browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
@@ -92,5 +92,5 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     return;
   }
 
-  await loadTabMetadata(tab.url);
+  await loadTabMetadata(tab.url, true);
 });

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -5,6 +5,7 @@ const DEFAULTS = {
   baseUrl: "",
   token: "",
   default_tags: "",
+  precacheEnabled: false,
 };
 
 export async function getConfiguration() {

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -5,6 +5,7 @@
   let baseUrl = "";
   let token = "";
   let default_tags = "";
+  let precacheEnabled = false;
   let isSuccess = false;
   let isError = false;
 
@@ -13,6 +14,7 @@
     baseUrl = config.baseUrl;
     token = config.token;
     default_tags = config.default_tags;
+    precacheEnabled = config.precacheEnabled;
   }
 
   init();
@@ -22,6 +24,7 @@
       baseUrl,
       token,
       default_tags,
+      precacheEnabled,
     };
 
     const testResult = await new LinkdingApi(config).testConnection(config);
@@ -62,6 +65,16 @@
     <input class="form-input" type="text" id="input-default-tags" placeholder="" bind:value={default_tags}>
     <div class="form-input-hint">
       Set of tags that should be added to new bookmarks by default.
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="form-checkbox">
+      <input type="checkbox" bind:checked={precacheEnabled}>
+      <i class="form-icon"></i>
+      <span>Pre-fill page information in Add Bookmark window</span>
+    </label>
+    <div class="form-input-hint">
+     <strong>Note:</strong> This will send the URL of all tabs to your Linkding server as you browse.
     </div>
   </div>
   <div class="divider"></div>

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -71,10 +71,15 @@
     <label class="form-checkbox">
       <input type="checkbox" bind:checked={precacheEnabled}>
       <i class="form-icon"></i>
-      <span>Pre-fill page information in Add Bookmark window</span>
+      <span>Pre-load page information while browsing</span>
     </label>
     <div class="form-input-hint">
-     <strong>Note:</strong> This will send the URL of all tabs to your Linkding server as you browse.
+      Pre-loads the page title and description while browsing, so that these are already available when opening the add
+      bookmark popup. Otherwise the page title and description will be fetched after opening popup, which can take a
+      moment for them to show up.
+      <br>
+      <strong>Note:</strong> This will send the URL of all websites that you visit to your Linkding server, which will
+      also be stored in the server logs.
     </div>
   </div>
   <div class="divider"></div>


### PR DESCRIPTION
Disable page metadata pre-caching by default, adding a checkbox in extension settings to turn this feature on and off (issue #36).