### PR TITLE
Close popup window after bookmark saved (#13)

### DIFF
--- a/src/form.svelte
+++ b/src/form.svelte
@@ -17,6 +17,7 @@
   let errorMessage = "";
   let availableTagNames = []
   let bookmarkExists = false;
+  let closeTimeout = 1000;
 
   $: {
     if (api && configuration) {
@@ -68,6 +69,9 @@
       await api.saveBookmark(bookmark);
       await clearCachedTabMetadata();
       saveState = "success";
+      setTimeout(() => {
+        window.close();
+      }, closeTimeout);
     } catch (e) {
       saveState = "error";
       errorMessage = e.toString();


### PR DESCRIPTION
Fix for issue #13:

- Automatically close the "add bookmark" popup window after a successful save
- Slight delay to display the "saved" message
- Does not close window if there was an error whilst attempting to save