### PR TITLE
Introduce automatic bookmarking when upvoting on Hacker News

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,14 @@
     "scripts": ["build/background.js"]
   },
 
+  "content_scripts": [
+    {
+      "matches": ["https://news.ycombinator.com/*"],
+      "js": ["build/contentscript.js"],
+      "run_at": "document_start"
+    }
+  ],
+
   "omnibox": {
     "keyword": "ld"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,5 +63,19 @@ export default [
 		watch: {
 			clearScreen: false
 		}
+	},
+	{
+		input: 'src/contentscript.js',
+		output: {
+			sourcemap: true,
+			format: 'iife',
+			file: 'build/contentscript.js',
+		},
+		plugins: [
+			production && terser()
+		],
+		watch: {
+			clearScreen: false
+		}
 	}
 ];

--- a/src/background.js
+++ b/src/background.js
@@ -104,3 +104,19 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
   await loadTabMetadata(tab.url, true);
 });
+
+
+browser.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
+  if (request.method == "getConfiguration") {
+    configuration = await getConfiguration();
+    return {data: configuration}
+  } else if (request.method == "currentTabUrl") {
+    return new Promise((resolve, reject) => {
+      browser.tabs.query({active:true, currentWindow: true}, (tabs) => {
+        var activeTab = tabs[0];
+        var activeTabUrl = activeTab.url;
+        resolve({url: activeTabUrl})
+      })
+    })
+  }
+})

--- a/src/contentscript.js
+++ b/src/contentscript.js
@@ -1,0 +1,68 @@
+import { getBrowser } from "./browser";
+import { LinkdingApi } from "./linkding";
+
+const browser = getBrowser()
+const HN = 'https://news.ycombinator.com'
+let api = null
+let description = ""
+let unread = false
+let shared = false
+
+
+const saveBookmark = async (url, title, tag_names, notes) => {
+  let bookmark = {
+    url,
+    title,
+    description,
+    notes,
+    tag_names,
+    unread,
+    shared,
+  }
+
+  try {
+    await api.saveBookmark(bookmark);
+  } catch (e) {
+    saveState = "error";
+    errorMessage = e.toString();
+    console.error(errorMessage);
+  }
+}
+
+const voteHN = async (e) => {
+  let vote = e.target.closest(".votelinks")
+  if (!vote) {
+    return
+  }
+  let link = vote.nextSibling.querySelector("a")
+  let url = link.getAttribute("href")
+  let meta = vote.parentElement.nextSibling
+  if (url.startsWith("item")) {
+    url = `${HN}/${url}`
+  }
+  let internal_a = meta.querySelector(".clicky.hider").nextElementSibling
+  let internal_url = `${HN}/${internal_a.getAttribute("href")}`
+  let notes = `[Comments on Hacker News](${internal_url})`
+  let title = link.innerHTML
+  let tag = ["hackernews"]
+  await saveBookmark(url, title, tag, notes)
+}
+
+const handleUrl = (response) => {
+  var activeTabUrl = response.url;
+  if (activeTabUrl.startsWith(HN)) {
+    let vote_els = document.querySelectorAll('td a[href^="vote"]')
+    for (let el of vote_els) {
+      el.addEventListener("click", voteHN)
+    }
+  }
+}
+
+const domReady = async () => {
+  browser.runtime.sendMessage({method: "getConfiguration"}).then(async (response) => {
+    api = new LinkdingApi(response.data)
+    browser.runtime.sendMessage({method: "currentTabUrl"}).then(handleUrl)
+  });
+}
+
+document.addEventListener("DOMContentLoaded", domReady);


### PR DESCRIPTION
Fixes #61 

This is a first stab at introducing automatic bookmarking of links that you upvote on Hacker News. This can further be extended to support other services. 