### PR TITLE
Fix issue of not being able to open the browser action on mac

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "Alt+Shift+L"
+        "default": "Alt+Shift+L",
+        "mac": "Alt+Shift+L"
       },
       "description": "Open a popup to bookmark current page."
     }


### PR DESCRIPTION
Fixes #58 

Adding the "mac" key I could get this to work successfully. 