### PR TITLE
Add options to pre-select share or unread

### DIFF
--- a/src/form.svelte
+++ b/src/form.svelte
@@ -58,6 +58,8 @@
 
     titlePlaceholder = tabMetadata.metadata.title;
     descriptionPlaceholder = tabMetadata.metadata.description;
+    shared = configuration.shareSelected;
+    unread = configuration.unreadSelected;
 
     const existingBookmark = tabMetadata.bookmark;
     if (existingBookmark) {

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -78,16 +78,22 @@
     <label class="form-checkbox">
       <input type="checkbox" bind:checked={unreadSelected}>
       <i class="form-icon"></i>
-      <span>Unread is pre-selected when saving bookmark</span>
+      <span>Pre-select unread when adding bookmark</span>
     </label>
+    <div class="form-input-hint">
+      Marks new bookmarks as unread by default.
+    </div>
   </div>
 
   <div class="form-group">
     <label class="form-checkbox">
       <input type="checkbox" bind:checked={shareSelected}>
       <i class="form-icon"></i>
-      <span>Share is pre-selected when saving bookmark</span>
+      <span>Pre-select share when saving bookmark</span>
     </label>
+    <div class="form-input-hint">
+      Marks new bookmarks as shared by default. Only useful if you have enabled bookmark sharing in linkding.
+    </div>
   </div>
 
   <div class="form-group">

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -5,6 +5,8 @@
   let baseUrl = "";
   let token = "";
   let default_tags = "";
+  let shareSelected = false;
+  let unreadSelected = false;
   let precacheEnabled = false;
   let isSuccess = false;
   let isError = false;
@@ -15,6 +17,8 @@
     token = config.token;
     default_tags = config.default_tags;
     precacheEnabled = config.precacheEnabled;
+    shareSelected = config.shareSelected;
+    unreadSelected = config.unreadSelected;
   }
 
   init();
@@ -25,6 +29,8 @@
       token,
       default_tags,
       precacheEnabled,
+      shareSelected,
+      unreadSelected
     };
 
     const testResult = await new LinkdingApi(config).testConnection(config);
@@ -67,6 +73,23 @@
       Set of tags that should be added to new bookmarks by default.
     </div>
   </div>
+
+  <div class="form-group">
+    <label class="form-checkbox">
+      <input type="checkbox" bind:checked={unreadSelected}>
+      <i class="form-icon"></i>
+      <span>Unread is pre-selected when saving bookmark</span>
+    </label>
+  </div>
+
+  <div class="form-group">
+    <label class="form-checkbox">
+      <input type="checkbox" bind:checked={shareSelected}>
+      <i class="form-icon"></i>
+      <span>Share is pre-selected when saving bookmark</span>
+    </label>
+  </div>
+
   <div class="form-group">
     <label class="form-checkbox">
       <input type="checkbox" bind:checked={precacheEnabled}>


### PR DESCRIPTION
Fixes #52
Fixes #34 
Fixes #68

This PR adds options to always have share and unread pre-select when you add a new bookmark. 

It looks like this. 
<img width="626" alt="Screenshot 2024-01-20 at 12 36 11" src="https://github.com/sissbruecker/linkding-extension/assets/2124818/cac5e2e0-67f8-4922-8e72-04343786eab6">
