### PR TITLE
Make tag suggestions case-insensitive

### DIFF
--- a/src/TagAutocomplete.svelte
+++ b/src/TagAutocomplete.svelte
@@ -27,7 +27,7 @@
 
         const word = getCurrentWord(input);
 
-        suggestions = word ? tags.filter(tag => tag.indexOf(word) === 0) : [];
+        suggestions = word ? tags.filter(tag => tag.toLowerCase().indexOf(word.toLowerCase()) === 0) : [];
 
         if (word && suggestions.length > 0) {
             open();


### PR DESCRIPTION
This fixes case-insensitivity with tag auto-completion, using the same logic from the main linkding repo.