### PR TITLE
Allow using browser metadata

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 import { getBrowser, getCurrentTabInfo, showBadge, removeBadge } from "./browser";
-import { loadTabMetadata } from "./cache";
+import { loadServerMetadata } from "./cache";
 import { getConfiguration, isConfigurationComplete } from "./configuration";
 import { LinkdingApi } from "./linkding";
 
@@ -102,7 +102,7 @@ browser.omnibox.onInputEntered.addListener(async (content, disposition) => {
 
 browser.tabs.onActivated.addListener(async (activeInfo) => {
   const tabInfo = await getCurrentTabInfo();
-  let tabMetadata = await loadTabMetadata(tabInfo.url, true);
+  let tabMetadata = await loadServerMetadata(tabInfo.url, true);
   setDynamicBadge(activeInfo.tabId, tabMetadata);
 });
 
@@ -113,6 +113,6 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     return;
   }
 
-  let tabMetadata = await loadTabMetadata(tab.url, true);
+  let tabMetadata = await loadServerMetadata(tab.url, true);
   setDynamicBadge(tabId, tabMetadata);
 });

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,16 +1,89 @@
 export function getBrowser() {
-  return typeof browser !== 'undefined' ? browser : chrome;
+  return typeof browser !== "undefined" ? browser : chrome;
 }
 
 export async function getCurrentTabInfo() {
-  const tabs = await getBrowser().tabs.query({active: true, currentWindow: true});
+  const tabs = await getBrowser().tabs.query({
+    active: true,
+    currentWindow: true,
+  });
   const tab = tabs && tabs[0];
 
   return {
     id: tab ? tab.id : "",
     url: tab ? tab.url : "",
-    title: tab ? tab.title : ""
+    title: tab ? tab.title : "",
   };
+}
+
+function useChromeScripting() {
+  return typeof chrome !== "undefined" && !!chrome.scripting;
+}
+
+export async function getBrowserMetadata() {
+  const tabs = await getBrowser().tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  const tab = tabs && tabs[0];
+
+  const errorHandler = (error) => {
+    console.error("Failed to load browser metadata", error);
+    return { title: "", description: "" };
+  };
+
+  if (useChromeScripting()) {
+    function getMetadata() {
+      const title =
+        document.querySelector("title")?.textContent ||
+        document
+          .querySelector('meta[property="og:title"]')
+          ?.getAttribute("content") ||
+        "";
+      const description =
+        document
+          .querySelector('meta[name="description"]')
+          ?.getAttribute("content") ||
+        document
+          .querySelector('meta[property="og:description"]')
+          ?.getAttribute("content") ||
+        "";
+      return { title, description };
+    }
+
+    return getBrowser()
+      .scripting.executeScript({
+        target: { tabId: tab.id },
+        func: getMetadata,
+      })
+      .then((result) => result[0].result)
+      .catch(errorHandler);
+  } else {
+    const code = `
+      (function () {
+      const title =
+        document.querySelector("title")?.textContent ||
+        document
+          .querySelector('meta[property="og:title"]')
+          ?.getAttribute("content") ||
+        "";
+      const description =
+        document
+          .querySelector('meta[name="description"]')
+          ?.getAttribute("content") ||
+        document
+          .querySelector('meta[property="og:description"]')
+          ?.getAttribute("content") ||
+        "";
+        return { title, description };
+      })();
+    `;
+
+    return getBrowser()
+      .tabs.executeScript(tab.id, { code })
+      .then((result) => result[0])
+      .catch(errorHandler);
+  }
 }
 
 function useChromeStorage() {
@@ -20,7 +93,7 @@ function useChromeStorage() {
 export function getStorageItem(key) {
   if (useChromeStorage()) {
     const result = chrome.storage.local.get([key]);
-    return result.then(data => data[key])
+    return result.then((data) => data[key]);
   } else {
     return Promise.resolve(localStorage.getItem(key));
   }
@@ -28,7 +101,7 @@ export function getStorageItem(key) {
 
 export function setStorageItem(key, value) {
   if (useChromeStorage()) {
-    return chrome.storage.local.set({[key]: value});
+    return chrome.storage.local.set({ [key]: value });
   } else {
     localStorage.setItem(key, value);
     return Promise.resolve();
@@ -45,7 +118,10 @@ export function showBadge(tabId) {
   const action = browser.browserAction || browser.action;
   action.setBadgeText({ text: "★", tabId: tabId });
   action.setBadgeTextColor({ color: "#FFE234", tabId: tabId });
-  action.setBadgeBackgroundColor({ color: "rgba(100,100,100,1)", tabId: tabId });
+  action.setBadgeBackgroundColor({
+    color: "rgba(100,100,100,1)",
+    tabId: tabId,
+  });
 }
 
 export function removeBadge(tabId) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -2,11 +2,11 @@ import { getStorageItem, setStorageItem } from "./browser";
 import { getConfiguration, isConfigurationComplete } from "./configuration";
 import { LinkdingApi } from "./linkding";
 
-const TAB_METADATA_CACHE_KEY = "ld_tab_metadata_cache";
+const SERVER_METADATA_CACHE_KEY = "ld_server_metadata_cache";
 
-export async function loadTabMetadata(url, precacheRequest = false) {
+export async function loadServerMetadata(url, precacheRequest = false) {
   // the function should be called with precacheRequest = true
-  // anytime before the user has conciously decided to bookmark it.
+  // anytime before the user has consciously decided to bookmark it.
   // see https://github.com/sissbruecker/linkding-extension/issues/36
   const configuration = await getConfiguration();
   const hasCompleteConfiguration = isConfigurationComplete(configuration);
@@ -17,7 +17,7 @@ export async function loadTabMetadata(url, precacheRequest = false) {
   }
 
   // Check for cached metadata first
-  const cachedMetadata = await getCachedTabMetadata();
+  const cachedMetadata = await getCachedServerMetadata();
   if (cachedMetadata && cachedMetadata.metadata.url === url) {
     return cachedMetadata;
   }
@@ -32,7 +32,7 @@ export async function loadTabMetadata(url, precacheRequest = false) {
       if (tabMetadata.bookmark && !tabMetadata.bookmark.date_added) {
         tabMetadata.bookmark = await api.getBookmark(tabMetadata.bookmark.id);
       }
-      await cacheTabMetadata(tabMetadata);
+      await cacheServerMetadata(tabMetadata);
       return tabMetadata;
     } catch (e) {
       console.error(e);
@@ -44,16 +44,16 @@ export async function loadTabMetadata(url, precacheRequest = false) {
   }
 }
 
-export async function getCachedTabMetadata() {
-  const json = await getStorageItem(TAB_METADATA_CACHE_KEY);
+export async function getCachedServerMetadata() {
+  const json = await getStorageItem(SERVER_METADATA_CACHE_KEY);
   return json ? JSON.parse(json) : null;
 }
 
-export async function cacheTabMetadata(tabMetadata) {
+export async function cacheServerMetadata(tabMetadata) {
   const json = JSON.stringify(tabMetadata);
-  await setStorageItem(TAB_METADATA_CACHE_KEY, json);
+  await setStorageItem(SERVER_METADATA_CACHE_KEY, json);
 }
 
-export async function clearCachedTabMetadata() {
-  await cacheTabMetadata(null);
+export async function clearCachedServerMetadata() {
+  await cacheServerMetadata(null);
 }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -5,6 +5,7 @@ const DEFAULTS = {
   baseUrl: "",
   token: "",
   default_tags: "",
+  useBrowserMetadata: false,
   precacheEnabled: false,
 };
 

--- a/src/linkding.js
+++ b/src/linkding.js
@@ -26,7 +26,7 @@ export class LinkdingApi {
   async saveBookmark(bookmark) {
     const configuration = this.configuration;
 
-    return fetch(`${configuration.baseUrl}/api/bookmarks/`, {
+    return fetch(`${configuration.baseUrl}/api/bookmarks/?disable_scraping`, {
       method: "POST",
       headers: {
         Authorization: `Token ${configuration.token}`,

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -5,8 +5,9 @@
   let baseUrl = "";
   let token = "";
   let default_tags = "";
-  let shareSelected = false;
   let unreadSelected = false;
+  let shareSelected = false;
+  let useBrowserMetadata = false;
   let precacheEnabled = false;
   let isSuccess = false;
   let isError = false;
@@ -16,9 +17,10 @@
     baseUrl = config.baseUrl;
     token = config.token;
     default_tags = config.default_tags;
-    precacheEnabled = config.precacheEnabled;
-    shareSelected = config.shareSelected;
     unreadSelected = config.unreadSelected;
+    shareSelected = config.shareSelected;
+    useBrowserMetadata = config.useBrowserMetadata;
+    precacheEnabled = config.precacheEnabled;
   }
 
   init();
@@ -28,9 +30,10 @@
       baseUrl,
       token,
       default_tags,
-      precacheEnabled,
+      unreadSelected,
       shareSelected,
-      unreadSelected
+      useBrowserMetadata,
+      precacheEnabled,
     };
 
     const testResult = await new LinkdingApi(config).testConnection(config);
@@ -92,6 +95,20 @@
     </label>
     <div class="form-input-hint">
       Marks new bookmarks as shared by default. Only useful if you have enabled bookmark sharing in linkding.
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="form-checkbox">
+      <input type="checkbox" bind:checked={useBrowserMetadata}>
+      <i class="form-icon"></i>
+      <span>Use browser metadata</span>
+    </label>
+    <div class="form-input-hint">
+      By default, the extension will fetch the page title and description from the linkding server when adding a new
+      bookmark. Enabling this will use the metadata from the current browser tab instead. This gives better results
+      for websites that use bot detection or require login, but can give worse results for websites that don't properly
+      update the page title or description while browsing.
     </div>
   </div>
 


### PR DESCRIPTION
- Adds on option to use page title and description from the browser tab instead of fetching them through the server
- Prefill title and description as actual text so that it can be modified
- Allow clearing title or description

Closes https://github.com/sissbruecker/linkding-extension/issues/77
Closes https://github.com/sissbruecker/linkding-extension/issues/74
Closes https://github.com/sissbruecker/linkding-extension/issues/69
Closes https://github.com/sissbruecker/linkding-extension/issues/78