### PR TITLE
Fix issue where null is sent to save bookmark API

### DIFF
--- a/src/form.svelte
+++ b/src/form.svelte
@@ -102,6 +102,7 @@
 
   async function handleSubmit() {
     const tagNames = tags.split(" ").map(tag => tag.trim()).filter(tag => !!tag);
+    description =  description ? description : ""
     const bookmark = {
       url,
       title,

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -102,11 +102,10 @@
 
   async function handleSubmit() {
     const tagNames = tags.split(" ").map(tag => tag.trim()).filter(tag => !!tag);
-    description =  description ? description : ""
     const bookmark = {
       url,
-      title,
-      description,
+      title: title || "",
+      description: description || "",
       notes,
       tag_names: tagNames,
       unread,


### PR DESCRIPTION
Issue: Some websites, such as this [mastodon page](https://mastodon.social/@AJCxZ0@infosec.exchange/113205687391468478) have no description and so the check endpoint returns null to the extension for the description field. When the user goes to save, they get the message "Error saving bookmark: Validation error: {"description":["This field may not be null."]}".
This error does not occur when metadata is loaded from the browser instead of the server.

Solution: When a description is falsy, an empty string will be sent to the save bookmark API.

Related: https://github.com/sissbruecker/linkding/pull/871