### PR TITLE
Add option to automatically close the Bookmark popup window on save

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -7,6 +7,8 @@ const DEFAULTS = {
   default_tags: "",
   useBrowserMetadata: false,
   precacheEnabled: false,
+  closeAddBookmarkWindowOnSave: false,
+  closeAddBookmarkWindowOnSaveMs: 500,
 };
 
 export async function getConfiguration() {

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -123,6 +123,12 @@
       if (extensionConfiguration?.precacheEnabled) {
         showBadge(tabInfo.id);
       }
+
+      if (extensionConfiguration?.closeAddBookmarkWindowOnSave === true && extensionConfiguration?.closeAddBookmarkWindowOnSaveMs >= 0) {
+        window.setTimeout(() => {
+          window.close()
+        }, extensionConfiguration?.closeAddBookmarkWindowOnSaveMs);
+      }
     } catch (e) {
       saveState = "error";
       errorMessage = e.toString();

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -156,9 +156,6 @@
       <input class="form-input" type="number" id="input-close-window-on-save-time" placeholder="500" bind:value={closeAddBookmarkWindowOnSaveMs}>
       <div class="form-input-hint">
         The time in milliseconds to wait before closing the bookmark popup window after saving a bookmark.
-        <br>
-        <br>
-        <strong>Default:</strong> 500
       </div>
     </div>
   {/if}

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -9,6 +9,8 @@
   let shareSelected = false;
   let useBrowserMetadata = false;
   let precacheEnabled = false;
+  let closeAddBookmarkWindowOnSave = false;
+  let closeAddBookmarkWindowOnSaveMs = 500;
   let isSuccess = false;
   let isError = false;
 
@@ -21,6 +23,8 @@
     shareSelected = config.shareSelected;
     useBrowserMetadata = config.useBrowserMetadata;
     precacheEnabled = config.precacheEnabled;
+    closeAddBookmarkWindowOnSave = config.closeAddBookmarkWindowOnSave;
+    closeAddBookmarkWindowOnSaveMs = config.closeAddBookmarkWindowOnSaveMs;
   }
 
   init();
@@ -34,6 +38,8 @@
       shareSelected,
       useBrowserMetadata,
       precacheEnabled,
+      closeAddBookmarkWindowOnSave,
+      closeAddBookmarkWindowOnSaveMs,
     };
 
     const testResult = await new LinkdingApi(config).testConnection(config);
@@ -132,6 +138,31 @@
       also be stored in the server logs.
     </div>
   </div>
+
+  <div class="form-group">
+    <label class="form-checkbox">
+      <input type="checkbox" bind:checked={closeAddBookmarkWindowOnSave}>
+      <i class="form-icon"></i>
+      <span>Automatically close the popup window after saving a bookmark</span>
+    </label>
+    <div class="form-input-hint">
+      The popup window will automatically close once you’ve saved a bookmark, otherwise by default it will remain open until you close it.
+    </div>
+  </div>
+
+  {#if closeAddBookmarkWindowOnSave}
+    <div class="form-group">
+      <label class="form-label" for="input-close-window-on-save-time">Popup window close time delay after saving a bookmark<span class="text-error">*</span></label>
+      <input class="form-input" type="number" id="input-close-window-on-save-time" placeholder="500" bind:value={closeAddBookmarkWindowOnSaveMs}>
+      <div class="form-input-hint">
+        The time in milliseconds to wait before closing the bookmark popup window after saving a bookmark.
+        <br>
+        <br>
+        <strong>Default:</strong> 500
+      </div>
+    </div>
+  {/if}
+
   <div class="button-row">
     {#if isSuccess}
       <div class="status text-success mr-2">

--- a/src/options.svelte
+++ b/src/options.svelte
@@ -153,7 +153,7 @@
   {#if closeAddBookmarkWindowOnSave}
     <div class="form-group">
       <label class="form-label" for="input-close-window-on-save-time">Popup window close time delay after saving a bookmark<span class="text-error">*</span></label>
-      <input class="form-input" type="number" id="input-close-window-on-save-time" placeholder="500" bind:value={closeAddBookmarkWindowOnSaveMs}>
+      <input class="form-input" type="number" id="input-close-window-on-save-time" bind:value={closeAddBookmarkWindowOnSaveMs}>
       <div class="form-input-hint">
         The time in milliseconds to wait before closing the bookmark popup window after saving a bookmark.
       </div>


### PR DESCRIPTION
Related to https://github.com/sissbruecker/linkding-extension/pull/65

For reference, [Raindrop Firefox extension](https://addons.mozilla.org/en-US/firefox/addon/raindropio/) does this by default.

This adds a checkbox to allow the popup window to close.

By default, it is unchecked, so the current behaviour will remain.

<img width="650" alt="SCR-20250106-svcy" src="https://github.com/user-attachments/assets/d4a2e10e-6efb-4e53-9bda-6e89f30680c1" />

And on checking:

<img width="696" alt="SCR-20250106-svdp" src="https://github.com/user-attachments/assets/2500f4e9-45a0-4946-bd70-ee880a5e8dc9" />

Closes https://github.com/sissbruecker/linkding-extension/issues/13