### PR TITLE
Fix final slash on url

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -9,9 +9,10 @@ export async function getCurrentTabInfo() {
   });
   const tab = tabs && tabs[0];
 
+  // The new URI API https://caniuse.com/url keep the final slash always
   return {
     id: tab ? tab.id : "",
-    url: tab ? tab.url : "",
+    url: tab ? (new URL(tab.url)).href : "",
     title: tab ? tab.title : "",
   };
 }

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -55,8 +55,7 @@
 
   async function initForm() {
     tabInfo = await getCurrentTabInfo();
-    // The new URI API https://caniuse.com/url keep the final slash always
-    url = new URL(tabInfo.url).href;
+    url = tabInfo.url;
 
     loading = true;
     const [serverMetadata, browserMetadata] = await Promise.all([

--- a/src/form.svelte
+++ b/src/form.svelte
@@ -55,7 +55,8 @@
 
   async function initForm() {
     tabInfo = await getCurrentTabInfo();
-    url = tabInfo.url;
+    // The new URI API https://caniuse.com/url keep the final slash always
+    url = new URL(tabInfo.url).href;
 
     loading = true;
     const [serverMetadata, browserMetadata] = await Promise.all([


### PR DESCRIPTION
The final slash can be treat as a bug when considering the specs of URL API.

`(new URL('https://example.com')).href === (new URL('https://example.com/')).href` is true

This don't fix search params order (https://github.com/sissbruecker/linkding-extension/pull/99):

`(new URL('https://example.com?a=1&b=1')).href === (new URL('https://example.com?b=1&a1')).href` is false

```js
let example1 = (new URL('https://example.com?b=1&a1'))
example1.href // https://example.com?b=1&a1
example1.searchParams.sort()
example1.href // https://example.com/?a=1&b=1
```

Related to: https://github.com/sissbruecker/linkding/issues/957