### PR TITLE
fix: point to right locale automatically for Mozilla Addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with: Firefox, Chrome
 
 ## Installation
 
-Firefox: [Mozilla Addon Store](https://addons.mozilla.org/de/firefox/addon/linkding-extension/)
+Firefox: [Mozilla Addon Store](https://addons.mozilla.org/firefox/addon/linkding-extension/)
 
 Chrome: [Chrome Web Store](https://chrome.google.com/webstore/detail/linkding-extension/beakmhbijpdhipnjhnclmhgjlddhidpe) 
 


### PR DESCRIPTION
Not a big deal per se, but right now it defaults to the German locale. Simply dropping the locale makes it so that their server auto-detects your locale.

Thanks for your work on linkding—and the extensions!—happy user for a long time now.

---

💖