### PR TITLE
Feat: Add bookmark quick deletion with confirmation - Issue #119

### DIFF
--- a/src/linkding.js
+++ b/src/linkding.js
@@ -135,4 +135,35 @@ export class LinkdingApi {
       .then((body) => !!body.results)
       .catch(() => false);
   }
+
+  async deleteBookmark(bookmarkId) {
+    const configuration = this.configuration;
+
+    if(!bookmarkId || bookmarkId <= 0) {
+      return Promise.reject(`Invalid bookmark ID: ${bookmarkId}`);
+    }
+
+    return fetch(`${configuration.baseUrl}/api/bookmarks/${bookmarkId}/`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Token ${configuration.token}`,
+        "Content-Type": "application/json",
+      },
+      body: '',
+    }).then((response) => {
+      if (response.status === 201) {
+        return response.json();
+      } else if (response.status === 204) {
+        return null;
+      } else if (response.status === 400) {
+        return response
+          .json()
+          .then((body) =>
+            Promise.reject(`Validation error: ${JSON.stringify(body)}`)
+          );
+      } else {
+        return Promise.reject(`Request error: ${response.statusText}`);
+      }
+    });
+  }
 }


### PR DESCRIPTION
Introduce new feature to delete bookmarks directly from web extension ( Issue #119 ).

## How it works for user:
1. If saved bookmark is detected, 'Delete' button will be displayed.
2. Clicking 'Delete' button triggers confirmation step, displaying 'Cancel' and 'Confirm' buttons. 
3. Bookmark is only removed after user clicks 'Confirm'.

> Behavior is almost identical to original Linkding details page with 'Delete' button, but here 'Delete' button is left aligned and user cannot delete bookmark by accidentally double-clicking on 'Delete' button.

<img width="300" height="376" alt="delete_bookmark_step_1" src="https://github.com/user-attachments/assets/034cf1ea-b2e6-4069-a6ff-62ff555f25aa" />
<img width="300" height="376" alt="delete_bookmark_step_2" src="https://github.com/user-attachments/assets/fc711c32-b29b-478d-a0c5-fd098d24966e" />
<img width="300" height="376" alt="delete_bookmark_step_3" src="https://github.com/user-attachments/assets/f86af7a9-9fe6-4a0d-a721-fb930e4d9206" />

## Additional information to screenshots:

**This branch only adds function to delete bookmarks**. It does not change text of 'Save' button, nor does it add link to Linkding homepage, nor does it modify warning under the URL as shown in screenshots.
