### PR TITLE
Fix browser detection in Chrome

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -17,7 +17,15 @@ export async function getCurrentTabInfo() {
 }
 
 function isFirefox() {
-  return typeof browser !== "undefined";
+  const runtime = getBrowser().runtime;
+  if (runtime && typeof runtime.getURL === "function") {
+    const extensionUrl = runtime.getURL("");
+    return extensionUrl.startsWith("moz-extension://");
+  }
+
+  return (
+    typeof navigator !== "undefined" && navigator.userAgent.includes("Firefox/")
+  );
 }
 
 function useChromeScripting() {


### PR DESCRIPTION
isFirefox() used `typeof browser !== "undefined"`, which can be true in Chrome when a polyfill defines `browser`. This patch detects Firefox via `runtime.getURL("")` scheme (`moz-extension://`) with a user-agent fallback. Built successfully with ./build.sh.